### PR TITLE
Fix harcoded ACL on upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ package.json:
 
 config/plugins.js:
 
-```
+```js
 module.exports = ({ env }) => {
   //...
   upload: {
@@ -29,7 +29,8 @@ module.exports = ({ env }) => {
       params: {
         Bucket: env('AWS_S3_BUCKET'),
       },
-      cdn: env('AWS_CLOUDFRONT')
+      cdn: env('AWS_CLOUDFRONT'),
+      ACL: "public-read"  // OPTIONAL: if files are distributed via CDN, S3 bucket should be private, this field should be left empty.     
     },
   },
   //...

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ const _ = require('lodash');
 const AWS = require('aws-sdk');
 
 module.exports = {
-  init(config) {
+  init({ ACL, ...config }) {
     const S3 = new AWS.S3({
       apiVersion: '2006-03-01',
       ...config,
@@ -27,8 +27,8 @@ module.exports = {
             {
               Key: `${path}${file.hash}${file.ext}`,
               Body: Buffer.from(file.buffer, 'binary'),
-              ACL: 'public-read',
               ContentType: file.mime,
+              ACL,
               ...customParams,
             },
             (err, data) => {


### PR DESCRIPTION
Fixes https://github.com/strapi/strapi/issues/5868#issuecomment-1105746634

### Problem
Uploading files will hit `Access Denied` error if the S3 bucket does not have public read access, which is counter intuitive when you have CDN to distribute it publicly.

### The Fix
Instead of hardcoding `public-read` in the `S3.upload` function directly, we allow the ACL to be configurable in `plugins.js`, eg:

```js
module.exports = ({ env }) => ({
  upload: {
    provider: 'aws-s3-cloudfront',
    providerOptions: {
      accessKeyId: env('AWS_S3_ACCESS_KEY_ID'),
      secretAccessKey: env('AWS_ACCESS_SECRET'),
      region: env('AWS_REGION'),
      params: {
        Bucket: env('AWS_S3_BUCKET'),
      },
      cdn: env("AWS_CLOUDFRONT_URL"),
      ACL: 'public-read', // OPTIONAL:  leave it empty if we do not need public read access
    },
  },
});
``` 

